### PR TITLE
rspec command name change

### DIFF
--- a/lib/kicker/recipes/ruby.rb
+++ b/lib/kicker/recipes/ruby.rb
@@ -20,7 +20,7 @@ class Ruby
     # Defaults to `ruby' if test_type is `test' and `spec' if test_type is
     # `spec'.
     def runner_bin
-      @runner_bin ||= test_type == 'test' ? 'ruby' : 'spec'
+      @runner_bin ||= test_type == 'test' ? 'ruby' : 'rspec'
     end
     
     # Assigns the root directory of where test cases will be looked up.


### PR DESCRIPTION
rails 3 and rspec 2 changed the name of the spec command to rspec. this is a preliminary commit to support that... i'm also considering some updates to the readme but wanted to get some comments to ensure i wasn't doing it wrong. :)

thx
