### PR TITLE
replace invalid multibyte char with ' ...'

### DIFF
--- a/lib/kicker.rb
+++ b/lib/kicker.rb
@@ -67,7 +67,7 @@ class Kicker #:nodoc:
     end
     
     trap('INT') do
-      log "Exiting…"
+      log "Exiting ..."
       watch_dog.stop
       exit
     end


### PR DESCRIPTION
When run under Ruby 1.9 the following error is fixed:

```
kicker-2.3.0/lib/kicker.rb:70: invalid multibyte char (US-ASCII) (SyntaxError)
```

I'm still looking into whether the next error can be fixed ... it's a bit more involved ... sigh

```
no such file to load -- osx/cocoa (LoadError)
```
