### PR TITLE
Rails 3.2.0 support

### DIFF
--- a/lib/kicker/recipes/rails.rb
+++ b/lib/kicker/recipes/rails.rb
@@ -1,5 +1,6 @@
 # Need to define these modules and require core_ext/module, because AS breaks
 # if these aren't defined. Need to fix that in AS...
+require 'active_support/deprecation'
 require 'active_support/core_ext/module'
 module ActiveSupport #:nodoc:
   module CoreExtensions #:nodoc:
@@ -18,7 +19,7 @@ class Rails < Ruby
     %w{ test_type runner_bin test_cases_root test_options }.each do |delegate|
       define_method(delegate) { Ruby.send(delegate) }
     end
-    
+
     # Maps +type+, for instance `models', to a test directory.
     def type_to_test_dir(type)
       if test_type == 'test'
@@ -55,7 +56,7 @@ class Rails < Ruby
       end
     end
   end
-  
+
   # Returns an array of all tests related to the given model.
   def tests_for_model(model)
     if test_type == 'test'
@@ -72,37 +73,37 @@ class Rails < Ruby
       }
     end.map { |f| test_file f }
   end
-  
+
   def handle!
     @tests.concat(@files.take_and_map do |file|
       case file
       # Run all functional tests when routes.rb is saved
       when 'config/routes.rb'
         Rails.all_controller_tests
-      
+
       # Match lib/*
       when /^(lib\/.+)\.rb$/
         test_file($1)
-      
+
       # Map fixtures to their related tests
       when %r{^#{test_cases_root}/fixtures/(\w+)\.yml$}
         tests_for_model($1)
-      
+
       # Match any file in app/ and map it to a test file
       when %r{^app/(\w+)([\w/]*)/([\w\.]+)\.\w+$}
         type, namespace, file = $1, $2, $3
-        
+
         if dir = Rails.type_to_test_dir(type)
           if type == "views"
             namespace = namespace.split('/')[1..-1]
             file = "#{namespace.pop}_controller"
           end
-          
+
           test_file File.join(dir, namespace, file)
         end
       end
     end)
-    
+
     # And let the Ruby handler match other stuff.
     super
   end
@@ -111,9 +112,9 @@ end
 recipe :rails do
   require 'rubygems' rescue LoadError
   require 'active_support/core_ext/string'
-  
+
   process Rails
-  
+
   # When changing the schema, prepare the test database.
   process do |files|
     execute 'rake db:test:prepare' if files.delete('db/schema.rb')


### PR DESCRIPTION
This pull request fixed a problem with kicker and Rails 3.2.0.

Previous to this fix, when I use kicker with Rails 3.2.0 obtain an error. The trace:

/Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/activesupport-3.2.0/lib/active_support/core_ext/module/deprecation.rb:7:in `deprecate': uninitialized constant ActiveSupport::Deprecation (NameError)
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/activesupport-3.2.0/lib/active_support/core_ext/module/synchronization.rb:44:in`class:Module'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/activesupport-3.2.0/lib/active_support/core_ext/module/synchronization.rb:6:in `<top (required)>'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/activesupport-3.2.0/lib/active_support/core_ext/module.rb:8:in`<top (required)>'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:59:in `require'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:59:in`rescue in require'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker/recipes/rails.rb:4:in`<top (required)>'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker/recipes.rb:56:in `block in <module:Recipes>'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker/recipes.rb:56:in`each'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker/recipes.rb:56:in `<module:Recipes>'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker/recipes.rb:30:in`class:Kicker'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker/recipes.rb:29:in `<top (required)>'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/lib/kicker.rb:122:in`<top (required)>'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/goomerko/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/gems/kicker-2.3.1/bin/kicker:9:in `<top (required)>'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/bin/kicker:19:in`load'
    from /Users/goomerko/.rvm/gems/ruby-1.9.3-p0@rankem/bin/kicker:19:in `<main>'

This pull request fixed this problem, adding the line [require 'active_support/deprecation'] on top of lib/kicker/recipes/rails.rb
