### PR TITLE
Use the 'listen' gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     kicker (2.5.0)
-      rb-fsevent
+      listen
 
 GEM
   remote: http://rubygems.org/
@@ -10,14 +10,23 @@ GEM
     activesupport (3.2.1)
       i18n (~> 0.6)
       multi_json (~> 1.0)
+    ffi (1.0.11)
     i18n (0.6.0)
     json (1.6.5)
+    listen (0.4.3)
+      rb-fchange (~> 0.0.5)
+      rb-fsevent (~> 0.9.1)
+      rb-inotify (~> 0.8.8)
     metaclass (0.0.1)
     mocha (0.10.3)
       metaclass (~> 0.0.1)
     multi_json (1.0.4)
     rake (0.9.2.2)
-    rb-fsevent (0.9.0)
+    rb-fchange (0.0.5)
+      ffi
+    rb-fsevent (0.9.1)
+    rb-inotify (0.8.8)
+      ffi (>= 0.5.0)
     rdoc (3.12)
       json (~> 1.4)
     test-spec (0.10.0)

--- a/kicker.gemspec
+++ b/kicker.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version  = Kicker::VERSION
   s.date     = Date.today
 
-  s.summary  = "A lean, agnostic, flexible file-change watcher, using OS X FSEvents."
+  s.summary  = "A lean, agnostic, flexible file-change watcher."
   s.authors  = ["Eloy Duran", "Manfred Stienstra"]
   s.homepage = "http://github.com/alloy/kicker"
   s.email    = %w{ eloy.de.enige@gmail.com manfred@fngtps.com }
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files            = Dir['bin/kicker', '{lib,vendor}/**/*.rb', 'README.rdoc', 'LICENSE', 'html/images/kikker.jpg']
   s.extra_rdoc_files = %w{ LICENSE README.rdoc }
 
-  s.add_runtime_dependency("rb-fsevent")
+  s.add_runtime_dependency("listen")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("rdoc") # purely so it doesn't warn about deprecated rake task

--- a/lib/kicker.rb
+++ b/lib/kicker.rb
@@ -95,7 +95,7 @@ class Kicker #:nodoc:
   end
   
   def files_in_directory(dir)
-    Dir.entries(dir)[2..-1].map { |f| File.join(dir, f) }
+    Dir.entries(dir).sort[2..-1].map { |f| File.join(dir, f) }
   rescue Errno::ENOENT
     []
   end

--- a/lib/kicker/fsevents.rb
+++ b/lib/kicker/fsevents.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'rb-fsevent'
+require 'listen'
 
 class Kicker
   class FSEvents
@@ -23,11 +23,12 @@ class Kicker
     end
     
     def self.start_watching(paths, options={}, &block)
-      fsevent = ::FSEvent.new
-      fsevent.watch(paths, options) do |directories|
+      listener = Listen.to *paths, options
+      listener.change do |*args|
+        files = args.flatten
+        directories = files.map {|file| File.dirname file}.uniq
         yield directories.map { |directory| Kicker::FSEvents::FSEvent.new(directory) }
-      end
-      fsevent.run
+      end.start
     end
   end
 end

--- a/test/filesystem_change_test.rb
+++ b/test/filesystem_change_test.rb
@@ -84,6 +84,14 @@ describe "Kicker, when a change occurs" do
     @kicker.send(:process, [event()])
   end
   
+  it "should not break when directory entries are not sorted" do
+    sleep(1)
+    file = touch('1')
+    
+    Dir.stubs(:entries).returns([File.basename(file), ".", ".."])
+    @kicker.send(:changed_files, [event(file)]).should == [file]
+  end
+  
   private
   
   def touch(file)


### PR DESCRIPTION
These commits make kicker use the 'listen' gem, allowing it to work on Linux as well.

Fixes issue #7.

Caveat: Not tested on MacOS X.
