### PR TITLE
Fix fake fs tests

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Kicker
 
-{<img src="https://secure.travis-ci.org/alloy/kicker.png" />}[http://travis-ci.org/alloy/kicker]
+{<img src="https://travis-ci.org/alloy/kicker.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/alloy/kicker]
 
 A lean, agnostic, flexible file-change watcher.
 

--- a/kicker.gemspec
+++ b/kicker.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("bacon")
   s.add_development_dependency("mocha-on-bacon")
   s.add_development_dependency("activesupport")
-  s.add_development_dependency("fakefs")
+  s.add_development_dependency("fakefs", '>= 0.5')
 end
 

--- a/spec/recipes_spec.rb
+++ b/spec/recipes_spec.rb
@@ -17,6 +17,7 @@ describe "Kicker::Recipes" do
   before do
     FakeFS.activate!
     FakeFS::FileSystem.clone(RECIPES_PATH)
+    Dir.chdir(File.absolute_path('../../', __FILE__))
   end
 
   after do
@@ -31,7 +32,7 @@ describe "Kicker::Recipes" do
   end
 
   it "loads local recipes" do
-    local = Pathname.new('~/.kick')
+    local = Pathname.new('~/.kick').expand_path
     local.mkpath
     recipe = local.join('some-random-recipe.rb')
     FileUtils.touch(recipe)


### PR DESCRIPTION
It looks like the build has been failing ever since fake fs 0.5 came out. The problem is that they stopped fake fs from taking copying the real current working directory and instead setting it to '/'. It also has issues with getting the user's home path (i.e. '~/').

I've fixed this in the tests by explicitly setting the cwd after starting up fake fs.

Oh and I updated the travis badge in the readme too, because the url it was using no longer seems to load.
